### PR TITLE
Wire the AI clustering path and add a preview screen

### DIFF
--- a/src-tauri/src/commands/cluster.rs
+++ b/src-tauri/src/commands/cluster.rs
@@ -24,6 +24,21 @@ pub struct CostEstimate {
     pub estimated_usd: f64,
 }
 
+#[derive(Serialize)]
+pub struct ClusterPreviewItem {
+    pub label: String,
+    pub count: i64,
+    pub titles: Vec<String>,
+    pub earliest: Option<String>,
+    pub latest: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ClusterPreview {
+    pub clusters: Vec<ClusterPreviewItem>,
+    pub total_clustered: i64,
+}
+
 #[derive(Clone, Serialize)]
 #[serde(tag = "event", content = "data", rename_all = "camelCase")]
 pub enum ClusterEvent {
@@ -200,4 +215,54 @@ pub async fn start_clustering(
             return Err(err);
         }
     }
+}
+
+#[tauri::command]
+pub async fn get_cluster_preview(state: State<'_, AppState>) -> Result<ClusterPreview, String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    let clusters = db::get_clusters_for_memory(&conn).map_err(|e| e.to_string())?;
+
+    let total_clustered: i64 = clusters.iter().map(|c| c.count).sum();
+
+    let items: Vec<ClusterPreviewItem> = clusters
+        .into_iter()
+        .map(|c| ClusterPreviewItem {
+            label: c.cluster_label,
+            count: c.count,
+            titles: c.titles.into_iter().take(5).collect(),
+            earliest: c.earliest.map(unix_to_date_str),
+            latest: c.latest.map(unix_to_date_str),
+        })
+        .collect();
+
+    Ok(ClusterPreview {
+        clusters: items,
+        total_clustered,
+    })
+}
+
+fn unix_to_date_str(ts: i64) -> String {
+    let mut days = ts / 86_400;
+    let mut year = 1970i32;
+    loop {
+        let days_in_year = if is_leap(year) { 366i64 } else { 365i64 };
+        if days < days_in_year { break; }
+        days -= days_in_year;
+        year += 1;
+    }
+    let month_lengths: [i64; 12] = [
+        31, if is_leap(year) { 29 } else { 28 },
+        31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
+    ];
+    let mut month = 1u32;
+    for &m in &month_lengths {
+        if days < m { break; }
+        days -= m;
+        month += 1;
+    }
+    format!("{}-{:02}-{:02}", year, month, days + 1)
+}
+
+fn is_leap(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,7 @@ pub fn run() {
             commands::keychain::delete_api_key,
             commands::cluster::estimate_cost,
             commands::cluster::start_clustering,
+            commands::cluster::get_cluster_preview,
             commands::export::export_conversations,
         ])
         .run(tauri::generate_context!())

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,37 @@
+import { useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { useAppStore } from './store/appStore';
+import { useCluster } from './hooks/useCluster';
 import { DropZone } from './components/DropZone';
 import { ProgressView } from './components/ProgressView';
 import { SummaryCard } from './components/SummaryCard';
 import { ExportSuccessScreen } from './screens/ExportSuccessScreen';
+import { ApiKeyScreen } from './screens/ApiKeyScreen';
+import { CostScreen } from './screens/CostScreen';
+import { ClusteringView } from './screens/ClusteringView';
+import { PreviewScreen } from './screens/PreviewScreen';
+import type { ClusterPreview } from './lib/bindings';
 
 interface ExportResult {
   files_written: number;
   folder_path: string;
   mcp_configured: boolean;
   media_extracted: number;
+}
+
+function BackButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="absolute top-4 left-4 text-neutral-300 hover:text-neutral-600 transition-colors p-1"
+      aria-label="Back"
+    >
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+        <path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    </button>
+  );
 }
 
 export default function App() {
@@ -22,13 +43,56 @@ export default function App() {
     reset,
     setExporting,
     setExportSuccess,
+    setAwaitingKey,
+    setPreview,
     exportPath,
     exportCount,
     mcpConfigured,
     mediaExtracted,
+    tokenEstimate,
+    costEstimateUsd,
+    clusterError,
+    clusterPreview,
+    elapsedSecs,
   } = useAppStore();
 
+  const { fetchCostEstimate, startClustering } = useCluster();
+
   const handleExport = async () => {
+    setExporting();
+    try {
+      const result = await invoke<ExportResult>('export_conversations');
+      setExportSuccess(result.folder_path, result.files_written, result.mcp_configured, result.media_extracted);
+    } catch (err) {
+      useAppStore.setState({ phase: 'error', error: String(err) });
+    }
+  };
+
+  const handleOrganizeWithAI = () => {
+    setAwaitingKey();
+  };
+
+  const handleBackToSummary = () => {
+    useAppStore.setState({ phase: 'complete' });
+  };
+
+  // Auto-fetch cost estimate once API key is stored
+  useEffect(() => {
+    if (phase === 'key-stored') {
+      fetchCostEstimate();
+    }
+  }, [phase]);
+
+  // Fetch cluster preview data when entering preview phase
+  useEffect(() => {
+    if (phase === 'preview' && !clusterPreview) {
+      invoke<ClusterPreview>('get_cluster_preview')
+        .then((result) => setPreview(result.clusters))
+        .catch((err) => useAppStore.setState({ phase: 'error', error: String(err) }));
+    }
+  }, [phase, clusterPreview]);
+
+  const handlePreviewConfirm = async () => {
     setExporting();
     try {
       const result = await invoke<ExportResult>('export_conversations');
@@ -45,27 +109,65 @@ export default function App() {
       {phase === 'exporting' && <ProgressView stage="Exporting conversations…" />}
 
       {phase === 'error' && (
-        <DropZone errorMessage={error ?? undefined} onReset={reset} />
+        <DropZone errorMessage={error ?? clusterError ?? undefined} onReset={reset} />
       )}
 
       {phase === 'complete' && summary && (
         <>
-          <button
-            onClick={reset}
-            className="absolute top-4 left-4 text-neutral-300 hover:text-neutral-600 transition-colors p-1"
-            aria-label="Back"
-          >
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
-              <path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-          </button>
+          <BackButton onClick={reset} />
           <SummaryCard
             total={summary.total}
             earliestYear={summary.earliestYear}
             latestYear={summary.latestYear}
             onExport={handleExport}
+            onOrganizeWithAI={handleOrganizeWithAI}
           />
         </>
+      )}
+
+      {phase === 'awaiting-key' && (
+        <>
+          <BackButton onClick={handleBackToSummary} />
+          <ApiKeyScreen initialError={clusterError ?? undefined} />
+        </>
+      )}
+
+      {phase === 'key-stored' && (
+        <>
+          <BackButton onClick={handleBackToSummary} />
+          <ProgressView stage="Checking API key..." />
+        </>
+      )}
+
+      {phase === 'cost-ready' && tokenEstimate !== null && costEstimateUsd !== null && (
+        <>
+          <BackButton onClick={handleBackToSummary} />
+          <CostScreen
+            tokens={tokenEstimate}
+            estimatedUsd={costEstimateUsd}
+            onProceed={startClustering}
+          />
+        </>
+      )}
+
+      {phase === 'clustering' && (
+        <ClusteringView stage={stage} elapsedSecs={elapsedSecs} />
+      )}
+
+      {phase === 'preview' && clusterPreview && (
+        <>
+          <BackButton onClick={handleBackToSummary} />
+          <PreviewScreen
+            clusters={clusterPreview}
+            totalClustered={clusterPreview.reduce((sum, c) => sum + c.count, 0)}
+            onConfirm={handlePreviewConfirm}
+            onCancel={handleBackToSummary}
+          />
+        </>
+      )}
+
+      {phase === 'preview' && !clusterPreview && (
+        <ProgressView stage="Loading preview..." />
       )}
 
       {phase === 'export-success' && exportPath && exportCount !== null && (

--- a/src/components/SummaryCard.tsx
+++ b/src/components/SummaryCard.tsx
@@ -6,6 +6,7 @@ interface SummaryCardProps {
   earliestYear: number;
   latestYear: number;
   onExport: () => void;
+  onOrganizeWithAI?: () => void;
 }
 
 export function SummaryCard({
@@ -13,6 +14,7 @@ export function SummaryCard({
   earliestYear,
   latestYear,
   onExport,
+  onOrganizeWithAI,
 }: SummaryCardProps) {
   const [isExportHovered, setIsExportHovered] = useState(false);
 
@@ -57,6 +59,15 @@ export function SummaryCard({
           >
             Export to Claude
           </button>
+
+          {onOrganizeWithAI && (
+            <button
+              onClick={onOrganizeWithAI}
+              className="text-xs text-neutral-400 hover:text-neutral-600 transition-colors underline underline-offset-2"
+            >
+              Organize with AI
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -27,3 +27,17 @@ export type ClusterEvent =
 export type StartClusteringArgs = {
   // No args needed — cluster command reads from SQLite and Keychain internally
 };
+
+// ClusterPreview — must stay in sync with src-tauri/src/commands/cluster.rs
+export interface ClusterPreviewItem {
+  label: string;
+  count: number;
+  titles: string[];
+  earliest: string | null;
+  latest: string | null;
+}
+
+export interface ClusterPreview {
+  clusters: ClusterPreviewItem[];
+  total_clustered: number;
+}

--- a/src/screens/PreviewScreen.tsx
+++ b/src/screens/PreviewScreen.tsx
@@ -1,0 +1,62 @@
+import type { ClusterPreviewItem } from '../store/appStore';
+
+interface PreviewScreenProps {
+  clusters: ClusterPreviewItem[];
+  totalClustered: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function PreviewScreen({ clusters, totalClustered, onConfirm, onCancel }: PreviewScreenProps) {
+  return (
+    <div className="flex flex-col items-center gap-6 w-full max-w-md px-6">
+      <p className="text-sm text-neutral-600 text-center">
+        <span className="font-medium text-neutral-800">{totalClustered}</span>{' '}
+        conversation{totalClustered !== 1 ? 's' : ''} organized into{' '}
+        <span className="font-medium text-neutral-800">{clusters.length}</span>{' '}
+        project{clusters.length !== 1 ? 's' : ''}
+      </p>
+
+      <div className="w-full max-h-64 overflow-y-auto rounded-xl border border-neutral-200 bg-white divide-y divide-neutral-100">
+        {clusters.map((cluster) => (
+          <div key={cluster.label} className="px-4 py-3">
+            <div className="flex items-baseline justify-between gap-2">
+              <p className="text-sm font-medium text-neutral-800 truncate">{cluster.label}</p>
+              <span className="text-xs text-neutral-400 shrink-0">{cluster.count}</span>
+            </div>
+            {cluster.earliest && cluster.latest && (
+              <p className="text-xs text-neutral-400 mt-0.5">
+                {cluster.earliest} &ndash; {cluster.latest}
+              </p>
+            )}
+            {cluster.titles.length > 0 && (
+              <ul className="mt-1.5 space-y-0.5">
+                {cluster.titles.slice(0, 3).map((title) => (
+                  <li key={title} className="text-xs text-neutral-500 truncate">
+                    {title}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex flex-col items-center gap-3 w-full">
+        <button
+          onClick={onConfirm}
+          className="px-8 py-2.5 rounded-lg bg-neutral-900 text-white text-sm font-medium
+                     hover:bg-neutral-700 transition-colors"
+        >
+          Confirm and Export
+        </button>
+        <button
+          onClick={onCancel}
+          className="text-sm text-neutral-400 hover:text-neutral-600 transition-colors underline underline-offset-2"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -10,6 +10,7 @@ export type AppPhase =
   | 'key-stored'           // AI path: key confirmed — ready to fetch cost
   | 'cost-ready'           // AI path: show CostScreen
   | 'clustering'           // AI path: batch polling active
+  | 'preview'              // AI path: show cluster preview before export
   | 'error';
 
 export type ExportMode = 'with-ai' | 'without-ai' | null;
@@ -18,6 +19,14 @@ export interface Summary {
   total: number;
   earliestYear: number;
   latestYear: number;
+}
+
+export interface ClusterPreviewItem {
+  label: string;
+  count: number;
+  titles: string[];
+  earliest: string | null;
+  latest: string | null;
 }
 
 interface AppState {
@@ -37,6 +46,7 @@ interface AppState {
   batchId: string | null;
   clusterError: string | null;
   elapsedSecs: number;
+  clusterPreview: ClusterPreviewItem[] | null;
 
   // Phase 1 actions
   setStage: (stage: string) => void;
@@ -55,6 +65,7 @@ interface AppState {
   setClustering: (batchId: string) => void;
   setClusteringComplete: () => void;
   setClusterError: (msg: string) => void;
+  setPreview: (items: ClusterPreviewItem[]) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -73,6 +84,7 @@ export const useAppStore = create<AppState>((set) => ({
   batchId: null,
   clusterError: null,
   elapsedSecs: 0,
+  clusterPreview: null,
 
   // Phase 1
   setStage: (stage) => set({ phase: 'parsing', stage, error: null }),
@@ -82,7 +94,7 @@ export const useAppStore = create<AppState>((set) => ({
     phase: 'idle', stage: '', error: null, summary: null,
     exportMode: null, exportPath: null, exportCount: null, mcpConfigured: null, mediaExtracted: null,
     tokenEstimate: null, costEstimateUsd: null, batchId: null,
-    clusterError: null, elapsedSecs: 0,
+    clusterError: null, elapsedSecs: 0, clusterPreview: null,
   }),
 
   // Export path
@@ -96,6 +108,7 @@ export const useAppStore = create<AppState>((set) => ({
   setCostReady: (tokenEstimate, costEstimateUsd) =>
     set({ phase: 'cost-ready', tokenEstimate, costEstimateUsd }),
   setClustering: (batchId) => set({ phase: 'clustering', batchId }),
-  setClusteringComplete: () => set({ phase: 'export-success', exportMode: 'with-ai' }),
+  setClusteringComplete: () => set({ phase: 'preview' }),
   setClusterError: (msg) => set({ phase: 'error', clusterError: msg }),
+  setPreview: (items) => set({ clusterPreview: items }),
 }));


### PR DESCRIPTION
Hey! This one connects the dots on the AI clustering flow.

All the pieces were already there -- the backend for API key storage, cost estimation, and batch clustering, plus the frontend screens (ApiKeyScreen, CostScreen, ClusteringView). They just weren't being rendered anywhere. After clustering finished it jumped straight to export-success with no way to see what happened.

## What this does

- Wires the orphaned AI screens into the main app flow in App.tsx
- Adds a new PreviewScreen so you can see your clusters (names, counts, date ranges, a few example titles) before committing to the export
- Adds an "Organize with AI" link on the summary card as the entry point into the AI path
- Adds a `get_cluster_preview` Tauri command that pulls cluster data from SQLite for the preview
- Back arrows on every AI screen so you can bail out to the summary whenever

## Flow

```
summary -> API key -> cost estimate -> clustering -> preview -> export
```

Each step has a back arrow to return to the summary. Cancel on cost or preview does the same.

## What's not changing

The without-AI "Export to Claude" path is completely untouched. No changes to the export output structure either -- that's a separate piece of work.

## Verified

- TypeScript compiles clean
- Vite bundles fine
- `cargo build --release` passes with no new warnings