### PR TITLE
Let users pick where to export instead of hardcoding ~/Documents

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -30,6 +30,7 @@ pub struct ExportResult {
 #[tauri::command]
 pub async fn export_conversations(
     state: State<'_, AppState>,
+    export_dir: Option<String>,
 ) -> Result<ExportResult, String> {
     let conversations = {
         let conn = state.db.lock().map_err(|e| e.to_string())?;
@@ -46,7 +47,10 @@ pub async fn export_conversations(
     };
 
     let home = std::env::var("HOME").map_err(|_| "Cannot determine home directory".to_string())?;
-    let root = PathBuf::from(&home).join("Documents").join("ChatGPT History");
+    let root = match export_dir {
+        Some(ref dir) => PathBuf::from(dir),
+        None => PathBuf::from(&home).join("Documents").join("ChatGPT History"),
+    };
     std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
 
     // Remove legacy Projects/ folder if present from an older export

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -1,3 +1,4 @@
+use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -11,6 +12,7 @@ pub struct ExportResult {
     pub folder_path: String,
     pub mcp_configured: bool,
     pub media_extracted: usize,
+    pub memory_path: Option<String>,
 }
 
 /// Exports all conversations as markdown files to ~/Documents/ChatGPT History/
@@ -129,12 +131,261 @@ pub async fn export_conversations(
     let export_path = root.to_string_lossy().to_string();
     let mcp_configured = update_claude_desktop_config(&home, &export_path).is_ok();
 
+    // Generate Claude Code auto-memory
+    let memory_path = {
+        let conn = state.db.lock().map_err(|e| e.to_string())?;
+        generate_claude_code_memory(&home, &export_path, &conversations, &conn)
+    };
+
     Ok(ExportResult {
         files_written,
         folder_path: export_path,
         mcp_configured,
         media_extracted: media_extracted + group_chats_written,
+        memory_path,
     })
+}
+
+// ── Claude Code memory generation ──────────────────────────────────────────────
+
+/// Derives the Claude Code project memory path from the export path.
+/// Claude Code stores per-project memory at ~/.claude/projects/-<path-with-dashes>/memory/
+fn derive_claude_code_project_path(home: &str, export_path: &str) -> PathBuf {
+    // Claude Code encodes the project path by replacing / with -
+    // e.g. /Users/chris/Documents/ChatGPT History → -Users-chris-Documents-ChatGPT History
+    let encoded = export_path.replace('/', "-");
+    PathBuf::from(home)
+        .join(".claude")
+        .join("projects")
+        .join(encoded)
+        .join("memory")
+}
+
+/// Generates MEMORY.md with cluster data (AI path). Kept under 200 lines.
+fn generate_memory_md_clustered(
+    dir: &PathBuf,
+    clusters: &[db::MemoryCluster],
+    total_count: usize,
+    year_range: &str,
+) -> Result<(), String> {
+    let mut content = String::new();
+    content.push_str("# ChatGPT History — Knowledge Base\n\n");
+    content.push_str(&format!(
+        "_{} conversations · {} · imported from ChatGPT export_\n\n",
+        total_count, year_range
+    ));
+    content.push_str("## Topic Clusters\n\n");
+    content.push_str("| Cluster | Conversations | Date Range |\n");
+    content.push_str("|---------|--------------|------------|\n");
+
+    for cluster in clusters {
+        let date_range = match (cluster.earliest, cluster.latest) {
+            (Some(e), Some(l)) => {
+                let ey = unix_to_year(e);
+                let ly = unix_to_year(l);
+                if ey == ly { ey } else { format!("{}–{}", ey, ly) }
+            }
+            _ => "—".to_string(),
+        };
+        content.push_str(&format!(
+            "| {} | {} | {} |\n",
+            cluster.cluster_label, cluster.count, date_range
+        ));
+    }
+
+    content.push_str("\n## Cluster Summaries\n\n");
+
+    // Budget remaining lines: ~200 total, header used ~10 + table rows
+    let lines_used = 10 + clusters.len();
+    let lines_per_cluster = if clusters.is_empty() {
+        0
+    } else {
+        (190usize.saturating_sub(lines_used)) / clusters.len()
+    };
+
+    for cluster in clusters {
+        content.push_str(&format!("### {}\n\n", cluster.cluster_label));
+        if let Some(ref summary) = cluster.summary {
+            // Truncate summary to fit within budget
+            let summary_lines: Vec<&str> = summary.lines().collect();
+            let max_lines = lines_per_cluster.saturating_sub(4).max(2);
+            let trimmed: Vec<&str> = summary_lines.into_iter().take(max_lines).collect();
+            content.push_str(&trimmed.join("\n"));
+            content.push_str("\n\n");
+        }
+        content.push_str(&format!(
+            "_See `{}.md` for details._\n\n",
+            slugify(&cluster.cluster_label)
+        ));
+    }
+
+    content.push_str("---\n_Auto-generated from ChatGPT export. Topic files have full details._\n");
+
+    std::fs::write(dir.join("MEMORY.md"), content).map_err(|e| e.to_string())
+}
+
+/// Generates MEMORY.md without cluster data (no-AI path). Uses conversation titles.
+fn generate_memory_md_unclustered(
+    dir: &PathBuf,
+    conversations: &[db::ExportRow],
+) -> Result<(), String> {
+    let all_titles: Vec<String> = conversations
+        .iter()
+        .filter_map(|c| c.title.clone())
+        .collect();
+    let top_topics = extract_top_topics(&all_titles, 20);
+
+    let years: Vec<i32> = conversations
+        .iter()
+        .filter_map(|c| c.created_at)
+        .filter_map(|ts| unix_to_year(ts).parse::<i32>().ok())
+        .collect();
+    let (earliest, latest) = years
+        .iter()
+        .fold((i32::MAX, i32::MIN), |(lo, hi), &y| (lo.min(y), hi.max(y)));
+    let year_range = if earliest == i32::MAX {
+        "Unknown".to_string()
+    } else if earliest == latest {
+        earliest.to_string()
+    } else {
+        format!("{}–{}", earliest, latest)
+    };
+
+    let mut content = String::new();
+    content.push_str("# ChatGPT History — Knowledge Base\n\n");
+    content.push_str(&format!(
+        "_{} conversations · {} · imported from ChatGPT export_\n\n",
+        conversations.len(),
+        year_range
+    ));
+
+    content.push_str("## Frequent Topics\n\n");
+    if top_topics.is_empty() {
+        content.push_str("_(no recurring topics detected)_\n\n");
+    } else {
+        for topic in &top_topics {
+            content.push_str(&format!("- {}\n", topic));
+        }
+        content.push_str("\n");
+    }
+
+    content.push_str("## Recent Conversations\n\n");
+    // Show last 50 conversations (most recent first) to stay under 200 lines
+    let recent: Vec<&db::ExportRow> = conversations.iter().rev().take(50).collect();
+    for conv in &recent {
+        let title = conv.title.as_deref().unwrap_or("Untitled");
+        let date = conv
+            .created_at
+            .map(|ts| unix_to_date_str(ts))
+            .unwrap_or_default();
+        content.push_str(&format!("- **{}** · {}\n", title, date));
+    }
+
+    content.push_str(
+        "\n---\n_Auto-generated from ChatGPT export. \
+         Run with AI analysis for richer cluster data._\n",
+    );
+
+    std::fs::write(dir.join("MEMORY.md"), content).map_err(|e| e.to_string())
+}
+
+/// Generates per-cluster topic files with full details.
+fn generate_topic_files(dir: &PathBuf, clusters: &[db::MemoryCluster]) -> Result<(), String> {
+    for cluster in clusters {
+        let filename = format!("{}.md", slugify(&cluster.cluster_label));
+        let mut content = String::new();
+        content.push_str(&format!("# {}\n\n", cluster.cluster_label));
+
+        let date_range = match (cluster.earliest, cluster.latest) {
+            (Some(e), Some(l)) => format!("{} to {}", unix_to_date_str(e), unix_to_date_str(l)),
+            _ => "Unknown".to_string(),
+        };
+        content.push_str(&format!(
+            "_{} conversations · {}_\n\n",
+            cluster.count, date_range
+        ));
+
+        if let Some(ref summary) = cluster.summary {
+            content.push_str("## Summary\n\n");
+            content.push_str(summary);
+            content.push_str("\n\n");
+        }
+
+        if let Some(ref instructions) = cluster.instructions {
+            content.push_str("## Key Patterns & Instructions\n\n");
+            content.push_str(instructions);
+            content.push_str("\n\n");
+        }
+
+        content.push_str("## Conversations\n\n");
+        for title in &cluster.titles {
+            content.push_str(&format!("- {}\n", title));
+        }
+        content.push('\n');
+
+        std::fs::write(dir.join(&filename), content).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Orchestrates Claude Code memory generation. Returns the memory directory path on success.
+fn generate_claude_code_memory(
+    home: &str,
+    export_path: &str,
+    conversations: &[db::ExportRow],
+    conn: &Connection,
+) -> Option<String> {
+    let memory_dir = derive_claude_code_project_path(home, export_path);
+
+    // Ensure .claude directory exists (Claude Code must have been used at least once)
+    let claude_dir = PathBuf::from(home).join(".claude");
+    if !claude_dir.exists() {
+        return None;
+    }
+
+    if let Err(_) = std::fs::create_dir_all(&memory_dir) {
+        return None;
+    }
+
+    let has_clusters = db::has_cluster_data(conn);
+
+    if has_clusters {
+        let clusters = match db::get_clusters_for_memory(conn) {
+            Ok(c) => c,
+            Err(_) => return None,
+        };
+
+        let years: Vec<i32> = conversations
+            .iter()
+            .filter_map(|c| c.created_at)
+            .filter_map(|ts| unix_to_year(ts).parse::<i32>().ok())
+            .collect();
+        let (earliest, latest) = years
+            .iter()
+            .fold((i32::MAX, i32::MIN), |(lo, hi), &y| (lo.min(y), hi.max(y)));
+        let year_range = if earliest == i32::MAX {
+            "Unknown".to_string()
+        } else if earliest == latest {
+            earliest.to_string()
+        } else {
+            format!("{}–{}", earliest, latest)
+        };
+
+        if generate_memory_md_clustered(&memory_dir, &clusters, conversations.len(), &year_range)
+            .is_err()
+        {
+            return None;
+        }
+        if generate_topic_files(&memory_dir, &clusters).is_err() {
+            return None;
+        }
+    } else {
+        if generate_memory_md_unclustered(&memory_dir, conversations).is_err() {
+            return None;
+        }
+    }
+
+    Some(memory_dir.to_string_lossy().to_string())
 }
 
 // ── Asset extraction ───────────────────────────────────────────────────────────

--- a/src-tauri/src/store/db.rs
+++ b/src-tauri/src/store/db.rs
@@ -68,6 +68,57 @@ pub fn get_all_conversations(conn: &Connection) -> Result<Vec<ConversationRow>> 
     rows.collect()
 }
 
+pub struct MemoryCluster {
+    pub cluster_label: String,
+    pub count: i64,
+    pub titles: Vec<String>,
+    pub summary: Option<String>,
+    pub instructions: Option<String>,
+    pub earliest: Option<i64>,
+    pub latest: Option<i64>,
+}
+
+/// Fetches cluster data grouped by cluster_label for Claude Code memory generation.
+pub fn get_clusters_for_memory(conn: &Connection) -> Result<Vec<MemoryCluster>> {
+    let mut stmt = conn.prepare(
+        "SELECT cluster_label, COUNT(*) as cnt,
+                GROUP_CONCAT(title, '|||') as titles,
+                MIN(summary) as summary,
+                MIN(instructions) as instructions,
+                MIN(created_at) as earliest,
+                MAX(created_at) as latest
+         FROM conversations
+         WHERE cluster_label IS NOT NULL AND cluster_label != ''
+         GROUP BY cluster_label
+         ORDER BY cnt DESC",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        let titles_str: String = row.get(2)?;
+        let titles: Vec<String> = titles_str.split("|||").map(|s| s.to_string()).collect();
+        Ok(MemoryCluster {
+            cluster_label: row.get(0)?,
+            count: row.get(1)?,
+            titles,
+            summary: row.get(3)?,
+            instructions: row.get(4)?,
+            earliest: row.get(5)?,
+            latest: row.get(6)?,
+        })
+    })?;
+    rows.collect()
+}
+
+/// Returns true if any conversations have cluster_label set (i.e., AI analysis was run).
+pub fn has_cluster_data(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT COUNT(*) FROM conversations WHERE cluster_label IS NOT NULL AND cluster_label != ''",
+        [],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|c| c > 0)
+    .unwrap_or(false)
+}
+
 pub struct ExportRow {
     pub id: String,
     pub title: Option<String>,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ interface ExportResult {
   folder_path: string;
   mcp_configured: boolean;
   media_extracted: number;
+  memory_path: string | null;
 }
 
 export default function App() {
@@ -26,13 +27,14 @@ export default function App() {
     exportCount,
     mcpConfigured,
     mediaExtracted,
+    memoryPath,
   } = useAppStore();
 
   const handleExport = async () => {
     setExporting();
     try {
       const result = await invoke<ExportResult>('export_conversations');
-      setExportSuccess(result.folder_path, result.files_written, result.mcp_configured, result.media_extracted);
+      setExportSuccess(result.folder_path, result.files_written, result.mcp_configured, result.media_extracted, result.memory_path);
     } catch (err) {
       useAppStore.setState({ phase: 'error', error: String(err) });
     }
@@ -74,6 +76,7 @@ export default function App() {
           folderPath={exportPath}
           mcpConfigured={mcpConfigured ?? false}
           mediaExtracted={mediaExtracted ?? 0}
+          memoryPath={memoryPath}
           onStartOver={reset}
         />
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { openUrl } from '@tauri-apps/plugin-opener';
+import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { useAppStore } from './store/appStore';
 import { DropZone } from './components/DropZone';
 import { ProgressView } from './components/ProgressView';
@@ -31,9 +32,18 @@ export default function App() {
   } = useAppStore();
 
   const handleExport = async () => {
+    const chosen = await openDialog({
+      directory: true,
+      title: 'Choose export folder',
+    });
+    // User cancelled the picker
+    if (chosen === null) return;
+
     setExporting();
     try {
-      const result = await invoke<ExportResult>('export_conversations');
+      const result = await invoke<ExportResult>('export_conversations', {
+        exportDir: chosen,
+      });
       setExportSuccess(result.folder_path, result.files_written, result.mcp_configured, result.media_extracted, result.memory_path);
     } catch (err) {
       useAppStore.setState({ phase: 'error', error: String(err) });

--- a/src/screens/ExportSuccessScreen.tsx
+++ b/src/screens/ExportSuccessScreen.tsx
@@ -7,10 +7,11 @@ interface ExportSuccessScreenProps {
   folderPath: string;
   mcpConfigured: boolean;
   mediaExtracted: number;
+  memoryPath: string | null;
   onStartOver: () => void;
 }
 
-export function ExportSuccessScreen({ count, folderPath, mcpConfigured, mediaExtracted, onStartOver }: ExportSuccessScreenProps) {
+export function ExportSuccessScreen({ count, folderPath, mcpConfigured, mediaExtracted, memoryPath, onStartOver }: ExportSuccessScreenProps) {
   const [isOpenHovered, setIsOpenHovered] = useState(false);
   const [isStartOverHovered, setIsStartOverHovered] = useState(false);
 
@@ -46,6 +47,11 @@ export function ExportSuccessScreen({ count, folderPath, mcpConfigured, mediaExt
             {mediaExtracted > 0 && (
               <p className="text-xs text-neutral-400">
                 + {mediaExtracted.toLocaleString()} images & files
+              </p>
+            )}
+            {memoryPath && (
+              <p className="text-xs text-neutral-400">
+                Claude Code memory ready
               </p>
             )}
             <p className="text-xs text-neutral-400">{displayPath}</p>

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -30,6 +30,7 @@ interface AppState {
   exportCount: number | null;       // files written on export-success
   mcpConfigured: boolean | null;    // whether Claude Desktop MCP was auto-configured
   mediaExtracted: number | null;    // images + group chats extracted from ZIP
+  memoryPath: string | null;        // Claude Code memory directory path
 
   // AI path fields
   tokenEstimate: number | null;
@@ -46,7 +47,7 @@ interface AppState {
 
   // Export path actions
   setExporting: () => void;
-  setExportSuccess: (path: string, count: number, mcpConfigured: boolean, mediaExtracted: number) => void;
+  setExportSuccess: (path: string, count: number, mcpConfigured: boolean, mediaExtracted: number, memoryPath: string | null) => void;
 
   // AI path actions
   setAwaitingKey: () => void;
@@ -67,6 +68,7 @@ export const useAppStore = create<AppState>((set) => ({
   exportCount: null,
   mcpConfigured: null,
   mediaExtracted: null,
+  memoryPath: null,
 
   tokenEstimate: null,
   costEstimateUsd: null,
@@ -80,15 +82,15 @@ export const useAppStore = create<AppState>((set) => ({
   setComplete: (summary) => set({ phase: 'complete', summary }),
   reset: () => set({
     phase: 'idle', stage: '', error: null, summary: null,
-    exportMode: null, exportPath: null, exportCount: null, mcpConfigured: null, mediaExtracted: null,
+    exportMode: null, exportPath: null, exportCount: null, mcpConfigured: null, mediaExtracted: null, memoryPath: null,
     tokenEstimate: null, costEstimateUsd: null, batchId: null,
     clusterError: null, elapsedSecs: 0,
   }),
 
   // Export path
   setExporting: () => set({ phase: 'exporting', exportMode: 'without-ai' }),
-  setExportSuccess: (path, count, mcpConfigured, mediaExtracted) =>
-    set({ phase: 'export-success', exportPath: path, exportCount: count, mcpConfigured, mediaExtracted }),
+  setExportSuccess: (path, count, mcpConfigured, mediaExtracted, memoryPath) =>
+    set({ phase: 'export-success', exportPath: path, exportCount: count, mcpConfigured, mediaExtracted, memoryPath }),
 
   // AI path
   setAwaitingKey: () => set({ phase: 'awaiting-key', exportMode: 'with-ai' }),


### PR DESCRIPTION
## Summary
- Adds a native folder picker before export starts
- If the user cancels the picker, nothing happens (no export triggered)
- The chosen directory is passed to the Rust export command

## What changed
**Backend** (`commands/export.rs`): `export_conversations` now takes an optional
`export_dir` parameter. If provided, it uses that path. If not, it falls back to
`~/Documents/ChatGPT History/` like before.

**Frontend** (`App.tsx`): Before calling the export command, opens a native macOS
folder picker via `@tauri-apps/plugin-dialog` (already installed and permitted).
The chosen path is passed as `exportDir` to the IPC call.

## Why
The current export always writes to `~/Documents/ChatGPT History/`. Not everyone
wants that -- some people keep project files in a specific folder, some use iCloud
Drive, some want it on an external drive. The dialog plugin was already in the
project, just not wired up for this.

## Test plan
- [ ] Click export, verify native folder picker appears
- [ ] Pick a custom folder, verify files land there
- [ ] Cancel the picker, verify nothing happens (no error, stays on summary screen)
- [ ] MCP config should point to the chosen path, not the old hardcoded one
- [ ] Export without AI path still works the same way